### PR TITLE
Fix stale Crowdin instructions in ReadMe

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -32,5 +32,17 @@ The authoritative list of supported languages is maintained at https://crowdin.c
 If you remove strings from FieldWorks you will need to get your system ready to run the `uploadUpdatesForTranslation` build target.
 
 1. Make sure that you have liblcm cloned locally, checked out to the right branch, and specified in your `LibraryDevelopment.properties` file.
-2. Set the `CROWDIN_API_KEY` to the version 1 Api key for the FieldWorks crowdin project.
+2. Set the `CROWDIN_API_KEY` environment variable to a Crowdin personal access token (Crowdin API v2 — `overcrowdin` is built on `Crowdin.Api` v2, which authenticates with a personal access token; the "version 1" project API key this step used to reference no longer exists) for an account with access to the FieldWorks Crowdin project.
 3. `build /t:uploadUpdatesForTranslation`
+
+This uploads `lists/LocalizableLists.xml` (and other localizable sources) to the `"latest"` branch of the Crowdin project, per FieldWorks' `crowdin.json`. Note that this repo's own `.github/workflows/fetch-crowdin.yml` downloads translations from the `"FieldWorks-9.0"` branch instead — check which branch your change needs to reach before assuming an upload or download is visible on the other side.
+
+**Semantic domain lists have independent copies elsewhere**
+
+`lists/LocalizableLists.xml` is the Crowdin source for semantic domain names, descriptions, and questions, but several other repos hold their own static copies of the same English text that are *not* regenerated when this file changes and must be updated by hand:
+- liblcm: `src/SIL.LCModel/Templates/SemDom.xml`
+- TheCombine: `deploy/scripts/semantic_domains/xml/SemanticDomains-*.xml`
+- webonary: `localizations/input/LocalizedLists-*.xml`
+- This repo's own root `LocalizedLists-*.xml` files
+
+If you edit the English text in `lists/LocalizableLists.xml`, check whether those copies need the same edit.


### PR DESCRIPTION
This repo's ReadMe has drifted:

- **Stale API key instructions.** Step 2 of "Removing or adding strings" said to set `CROWDIN_API_KEY` to a "version 1" Crowdin API key. `overcrowdin` is built on `Crowdin.Api` v2.42.0, which authenticates via `AccessToken` — i.e. a Crowdin **API v2 personal access token**, not a v1 project key. Anyone following the ReadMe literally would generate the wrong credential type.
- **Undocumented branch mismatch.** The upload (`build /t:uploadUpdatesForTranslation`, via FieldWorks' `crowdin.json`) targets Crowdin branch `"latest"`, but this repo's own `.github/workflows/fetch-crowdin.yml` downloads from `"FieldWorks-9.0"`. Nothing in the ReadMe warned about this, which is exactly the kind of thing that makes an upload look successful while never reaching the branch a downstream consumer reads from.
- **Undocumented independent copies.** `lists/LocalizableLists.xml` is the Crowdin source for semantic domain names/descriptions/questions, but liblcm, TheCombine, webonary, and this repo's own root `LocalizedLists-*.xml` files each hold static, non-auto-synced copies of the same English text. This is exactly the gap that produced the recent SemDom.xml sync issues.

Draft PR — flagging for review since this is contributor-facing documentation for a process I don't run day-to-day; happy to adjust wording/scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)