### PR TITLE
Update ReadMe steps for removing/adding strings

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -13,8 +13,9 @@ This repository no longer holds checked-in localizations (those are in Crowdin a
 If you remove strings from FieldWorks you will need to get your system ready and run the `uploadUpdatesForTranslation` build target.
 
 1. Make sure that you have liblcm cloned locally, checked out to the right branch, and set the `LcmRootDir` environment variable to the path of that clone.
-2. Set the `CROWDIN_API_KEY` environment variable to a Crowdin personal access token (Crowdin API v2 — `overcrowdin` is built on `Crowdin.Api` v2, which authenticates with a personal access token) for an account with access to the FieldWorks Crowdin project.
-3. From the FieldWorks repo root, run `.\build.ps1 -Target uploadUpdatesForTranslation`
+2. Clone this repository (FwLocalizations) into the FieldWorks repo root as `Localizations` (so the path is `<FieldWorks>/Localizations`). The build reads its `lists/` sources from there and writes generated files (`*.xlf`, `messages.pot`, `LCM/`, `l10ns/`) back into it.
+3. Set the `CROWDIN_API_KEY` environment variable to a Crowdin personal access token (Crowdin API v2 — `overcrowdin` is built on `Crowdin.Api` v2, which authenticates with a personal access token) for an account with access to the FieldWorks Crowdin project.
+4. From the FieldWorks repo root, run `.\build.ps1 -Target uploadUpdatesForTranslation`
 
 This uploads `lists/LocalizableLists.xml` (and other localizable sources) to the `"latest"` branch of the Crowdin project, per FieldWorks' `crowdin.json`. Check which branch your change needs to reach before assuming an upload or download is visible on the other side.
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -12,7 +12,7 @@ This repository no longer holds checked-in localizations (those are in Crowdin a
 
 If you remove strings from FieldWorks you will need to get your system ready and run the `uploadUpdatesForTranslation` build target.
 
-1. Make sure that you have liblcm cloned locally, checked out to the right branch, and set the `LcmRootDir` environment variable to the path of that clone. (This replaces the former `LibraryDevelopment.properties` mechanism; the FieldWorks localization build now reads `LcmRootDir` from the environment.)
+1. Make sure that you have liblcm cloned locally, checked out to the right branch, and set the `LcmRootDir` environment variable to the path of that clone.
 2. Set the `CROWDIN_API_KEY` environment variable to a Crowdin personal access token (Crowdin API v2 — `overcrowdin` is built on `Crowdin.Api` v2, which authenticates with a personal access token) for an account with access to the FieldWorks Crowdin project.
 3. From the FieldWorks repo root, run `.\build.ps1 -Target uploadUpdatesForTranslation`
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -13,7 +13,7 @@ This repository no longer holds checked-in localizations (those are in Crowdin a
 If you remove strings from FieldWorks you will need to get your system ready and run the `uploadUpdatesForTranslation` build target.
 
 1. Make sure that you have liblcm cloned locally, checked out to the right branch, and set the `LcmRootDir` environment variable to the path of that clone.
-2. Clone this repository (FwLocalizations) into the FieldWorks repo root as `Localizations` (so the path is `<FieldWorks>/Localizations`). The build reads its `lists/` sources from there and writes generated files (`*.xlf`, `messages.pot`, `LCM/`, `l10ns/`) back into it.
+2. Clone this repository (FwLocalizations) into the FieldWorks repo root as `Localizations` (so the path is `<FieldWorks>/Localizations`; see [FieldWorks `CONTRIBUTING.md`](https://github.com/sillsdev/FieldWorks/blob/main/Docs/CONTRIBUTING.md#optional-clone-fwlocalizations-for-translation-work)). The build reads its `lists/` sources from there and writes generated files (`*.xlf`, `messages.pot`, `LCM/`, `l10ns/`) back into it.
 3. Set the `CROWDIN_API_KEY` environment variable to a Crowdin personal access token (Crowdin API v2 — `overcrowdin` is built on `Crowdin.Api` v2, which authenticates with a personal access token) for an account with access to the FieldWorks Crowdin project.
 4. From the FieldWorks repo root, run `.\build.ps1 -Target uploadUpdatesForTranslation`
 

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -12,7 +12,7 @@ This repository no longer holds checked-in localizations (those are in Crowdin a
 
 If you remove strings from FieldWorks you will need to get your system ready and run the `uploadUpdatesForTranslation` build target.
 
-1. Make sure that you have liblcm cloned locally, checked out to the right branch, and specified in your `LibraryDevelopment.properties` file.
+1. Make sure that you have liblcm cloned locally, checked out to the right branch, and set the `LcmRootDir` environment variable to the path of that clone. (This replaces the former `LibraryDevelopment.properties` mechanism; the FieldWorks localization build now reads `LcmRootDir` from the environment.)
 2. Set the `CROWDIN_API_KEY` environment variable to a Crowdin personal access token (Crowdin API v2 — `overcrowdin` is built on `Crowdin.Api` v2, which authenticates with a personal access token) for an account with access to the FieldWorks Crowdin project.
 3. From the FieldWorks repo root, run `.\build.ps1 -Target uploadUpdatesForTranslation`
 


### PR DESCRIPTION
## Summary

Updates the **Removing or adding strings** steps in `ReadMe.md` so they match
how the FieldWorks localization build (`InstallerBuild.proj` → `Build/Localize.targets`)
actually works today. The old instructions were stale about where the liblcm
path comes from and were missing a required setup step; the list grows from 3
steps to 4.

## What changed in `ReadMe.md`

- **Step 1 — liblcm location.** The build no longer imports
  `LibraryDevelopment.properties`; it reads `LcmRootDir` from the environment
  (and fails with `LcmSrcDir '/src' was not found. ... now an environment
  variable.` when it is unset). Step 1 now says to set the `LcmRootDir`
  environment variable to your local liblcm clone instead of editing
  `LibraryDevelopment.properties`.
- **New step 2 — clone FwLocalizations into place.** The build uses
  `<FieldWorks>/Localizations` as this repository's working tree: it reads
  `lists/` sources from there and writes generated files (`*.xlf`,
  `messages.pot`, `LCM/`, `l10ns/`) back into it. A new step documents cloning
  this repo into the FieldWorks repo root as `Localizations`, linking the
  canonical instructions in
  [FieldWorks `CONTRIBUTING.md`](https://github.com/sillsdev/FieldWorks/blob/main/Docs/CONTRIBUTING.md#optional-clone-fwlocalizations-for-translation-work).
  Without this, the build fails with a `DirectoryNotFoundException` writing
  `Localizations\lists\GOLDEtic.en.xlf`.
- **Renumbering.** Setting `CROWDIN_API_KEY` and running
  `.\build.ps1 -Target uploadUpdatesForTranslation` are now steps 3 and 4
  (content unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
